### PR TITLE
fix: error readonly property reassign fix

### DIFF
--- a/packages/plugin-protocol-http/src/http.ts
+++ b/packages/plugin-protocol-http/src/http.ts
@@ -260,13 +260,25 @@ export default ({
                         });
                     }
 
-                    next({
-                        status: Status.ERROR,
-                        error: Object.assign(err, {
+                    try {
+                        Object.assign(err, {
                             code: 'ERR_HTTP_ERROR',
                             status: response && response.status,
                             body: responseBody,
-                        }) as HttpRequestError,
+                        });
+                    } catch (e) {
+                        Object.assign(err, {
+                            __response: {
+                                code: 'ERR_HTTP_ERROR',
+                                status: response && response.status,
+                                body: responseBody,
+                            }
+                        });
+                    }
+
+                    next({
+                        status: Status.ERROR,
+                        error: err as HttpRequestError,
                         response: responseBody,
                     });
                 })


### PR DESCRIPTION
У нас когда-то были ошибки `Attempted to assign to readonly property`, указывающие на конкретно эту строку. Предположил, что можно предотвратить в будущем за счет проверки на наличие уже существующих полей