### PR TITLE
fix(deduplicate): respect meta from others plugins

### DIFF
--- a/packages/cache-utils/src/constants/metaTypes.ts
+++ b/packages/cache-utils/src/constants/metaTypes.ts
@@ -1,2 +1,3 @@
 export const CACHE = 'cache';
+export const ETAG = 'CACHE_ETAG';
 export const PROTOCOL_HTTP = 'PROTOCOL_HTTP';


### PR DESCRIPTION
This will fix cases, when response `status` is lost for deduplicated requests.
Also, etag plugin is supported correctly.