### PR TITLE
feat: Export HTTP error classes from `@tinkoff/request-plugin-protocol-http`

### DIFF
--- a/packages/plugin-protocol-http/src/index.ts
+++ b/packages/plugin-protocol-http/src/index.ts
@@ -1,5 +1,6 @@
 export * from './utils';
 export * from './validators';
+export * from './errors'
 export { HttpMethods } from './constants';
 export { default } from './http';
 export type { Query, QuerySerializer } from '@tinkoff/request-url-utils';


### PR DESCRIPTION
Access to error classes is useful when we want to enhance the error interface. For example, the `HttpRequestError` class is defined with a `body: any` field. In some APIs, we expect responses in a specific format, and we may want to distinguish errors that contain a body matching this format:

```ts
interface SomePayloadFormat { ... }

export type SpecificApiHttpError = HttpRequestError & {
  body: SomeCustomFormat;
};
```

To achieve this, we need access to the error classes provided by the @tinkoff/request-plugin-protocol-http package. 